### PR TITLE
Make mrd_countup and set_meridim functions inline for optimization

### DIFF
--- a/src/meridian/meridim.hpp
+++ b/src/meridian/meridim.hpp
@@ -73,7 +73,7 @@ struct Meridim {
   uint16_t checksum; ///! CHECK SUM
 };
 
-void mrd_countup(Meridim &a_meridim) {
+inline void mrd_countup(Meridim &a_meridim) {
   if (MERIDIM_SEQUENTIAL_MAX <= a_meridim.sequential) {
     a_meridim.sequential = 0;
   } else {
@@ -81,7 +81,7 @@ void mrd_countup(Meridim &a_meridim) {
   }
 }
 
-void set_meridim(Meridim &a_meridim, uint8_t a_data[], int size) {
+inline void set_meridim(Meridim &a_meridim, uint8_t a_data[], int size) {
   if (MERIDIM_BYTE_SIZE <= size) {
     a_meridim.master_command = (uint16_t)((a_data[1] << 8) | a_data[0]);
     a_meridim.sequential = (uint16_t)((a_data[3] << 8) | a_data[2]);

--- a/src/meridian/mrd_util.hpp
+++ b/src/meridian/mrd_util.hpp
@@ -20,7 +20,7 @@ namespace meridian {
 /// @param a_arr 配列
 /// @param a_size 配列の長さ
 /// @return 0以外が入っている最大のIndex. すべて0の場合は1を返す.
-int mrd_max_used_index(const int a_arr[], int a_size) {
+inline int mrd_max_used_index(const int a_arr[], int a_size) {
   int max_index_tmp = 0;
   for (int i = 0; i < a_size; ++i) {
     if (a_arr[i] != 0) {


### PR DESCRIPTION
## Summary / 概要
RaspberryPiPicoでもビルドできるように修正

## Background & Purpose / 背景・目的
RaspberryPiPicoでビルドエラーになっていた

## Changes / 変更内容
- 関数にinlineを付けた

## Related Issues / 関連 Issue
なし

## Impact / 影響範囲
- [V] API / 関数名やプログラムのインターフェース
- [ ] UI / UX / 見た目や使用感
- [ ] Performance / 性能
- [ ] Configuration / コンフィグレーション
- [ ] Documentation / 文書
- [ ] Specification / 仕様
- [ ] Others / その他

## How to Test / 動作確認方法
1. RaspberryPiPicoでビルドできるか確認した

## Test Results / テスト結果
- [ ] Unit Test
- [ ] Integration Test
- [ ] Manual Test
- Result / 結果: 未実施

## Breaking Changes / 破壊的変更
- [V] None / なし
- [ ] Yes / あり  
  Details / 詳細:

## Points for Review / レビュー観点
- なし

## Additional Notes / 補足情報
- なし
